### PR TITLE
Fix SecurityException on Android 12+ by specifying receiver export status in broadcast receiver registration

### DIFF
--- a/android/src/main/java/org/eclipse/paho/android/service/AlarmPingSender.java
+++ b/android/src/main/java/org/eclipse/paho/android/service/AlarmPingSender.java
@@ -68,21 +68,28 @@ class AlarmPingSender implements MqttPingSender {
 
 	@Override
 	public void start() {
-		String action = MqttServiceConstants.PING_SENDER
-				+ comms.getClient().getClientId();
-		Log.d(TAG, "Register alarmreceiver to MqttService"+ action);
-		service.registerReceiver(alarmReceiver, new IntentFilter(action));
+			String action = MqttServiceConstants.PING_SENDER + comms.getClient().getClientId();
+			Log.d(TAG, "Register alarmreceiver to MqttService " + action);
 
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-      pendingIntent = PendingIntent.getBroadcast(service, 0, new Intent(
-        action), PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-    } else {
-      pendingIntent = PendingIntent.getBroadcast(service, 0, new Intent(
-        action), PendingIntent.FLAG_UPDATE_CURRENT);
-    }
+			IntentFilter intentFilter = new IntentFilter(action);
 
-		schedule(comms.getKeepAlive());
-		hasStarted = true;
+			// Specify the export status based on Android version
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+					service.registerReceiver(alarmReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED);
+			} else {
+					service.registerReceiver(alarmReceiver, intentFilter);
+			}
+
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+					pendingIntent = PendingIntent.getBroadcast(service, 0, new Intent(action),
+							PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+			} else {
+					pendingIntent = PendingIntent.getBroadcast(service, 0, new Intent(action),
+							PendingIntent.FLAG_UPDATE_CURRENT);
+			}
+
+			schedule(comms.getKeepAlive());
+			hasStarted = true;
 	}
 
 	@Override

--- a/android/src/main/java/org/eclipse/paho/android/service/MqttService.java
+++ b/android/src/main/java/org/eclipse/paho/android/service/MqttService.java
@@ -778,24 +778,34 @@ public class MqttService extends Service implements MqttTraceHandler {
 
   @SuppressWarnings("deprecation")
   private void registerBroadcastReceivers() {
-		if (networkConnectionMonitor == null) {
-			networkConnectionMonitor = new NetworkConnectionIntentReceiver();
-			registerReceiver(networkConnectionMonitor, new IntentFilter(
-					ConnectivityManager.CONNECTIVITY_ACTION));
-		}
+      if (networkConnectionMonitor == null) {
+          networkConnectionMonitor = new NetworkConnectionIntentReceiver();
+          IntentFilter networkFilter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
 
-		if (Build.VERSION.SDK_INT < 14 /**Build.VERSION_CODES.ICE_CREAM_SANDWICH**/) {
-			// Support the old system for background data preferences
-			ConnectivityManager cm = (ConnectivityManager) getSystemService(CONNECTIVITY_SERVICE);
-			backgroundDataEnabled = cm.getBackgroundDataSetting();
-			if (backgroundDataPreferenceMonitor == null) {
-				backgroundDataPreferenceMonitor = new BackgroundDataPreferenceReceiver();
-				registerReceiver(
-						backgroundDataPreferenceMonitor,
-						new IntentFilter(
-								ConnectivityManager.ACTION_BACKGROUND_DATA_SETTING_CHANGED));
-			}
-		}
+          // Specify export status based on Android version
+          if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+              registerReceiver(networkConnectionMonitor, networkFilter, Context.RECEIVER_NOT_EXPORTED);
+          } else {
+              registerReceiver(networkConnectionMonitor, networkFilter);
+          }
+      }
+
+      if (Build.VERSION.SDK_INT < 14 /** Build.VERSION_CODES.ICE_CREAM_SANDWICH **/) {
+          // Support the old system for background data preferences
+          ConnectivityManager cm = (ConnectivityManager) getSystemService(CONNECTIVITY_SERVICE);
+          backgroundDataEnabled = cm.getBackgroundDataSetting();
+          if (backgroundDataPreferenceMonitor == null) {
+              backgroundDataPreferenceMonitor = new BackgroundDataPreferenceReceiver();
+              IntentFilter backgroundDataFilter = new IntentFilter(ConnectivityManager.ACTION_BACKGROUND_DATA_SETTING_CHANGED);
+
+              // Specify export status based on Android version
+              if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                  registerReceiver(backgroundDataPreferenceMonitor, backgroundDataFilter, Context.RECEIVER_NOT_EXPORTED);
+              } else {
+                  registerReceiver(backgroundDataPreferenceMonitor, backgroundDataFilter);
+              }
+          }
+      }
   }
 
   private void unregisterBroadcastReceivers(){


### PR DESCRIPTION
This PR addresses the SecurityException issue on Android 12+ caused by missing receiver export status when registering broadcast receivers in the AlarmPingSender and MqttService classes. The receivers are now registered with Context.RECEIVER_NOT_EXPORTED for Android 12+ to comply with the new security requirements, ensuring the receivers are not exposed to other apps. This update maintains backward compatibility with older Android versions.